### PR TITLE
Updating jms/serializer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
         "doctrine/doctrine-module": ">=0.5.1",
-        "jms/serializer": "0.11.*"
+        "jms/serializer": "~0.11"
     },
     "require-dev": {
         "zendframework/zend-developer-tools": "dev-master"


### PR DESCRIPTION
This pull request updates the jms/serializer requirement to obtain the last version available and that has several improvement from the version currently required.

It uses the same requirement that is used in the JMSSerializerBundle mantained by the creator of the library:
https://github.com/schmittjoh/JMSSerializerBundle/blob/master/composer.json#L16
