### PR TITLE
Adding the ability to configure the naming strategy

### DIFF
--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -61,3 +61,19 @@ return array(
     // ...
 );
 ```
+
+Selecting naming strategy
+-------------------------------
+The default naming strategy is camel case. But you can switch to the identical
+naming strategy through configuration.
+
+```php
+return array(
+    // ...
+    'jms_serializer' => array(
+      'naming_strategy' => 'identical'
+    ), ),
+        ),
+    // ...
+);
+```

--- a/src/JMSSerializerModule/Module.php
+++ b/src/JMSSerializerModule/Module.php
@@ -19,6 +19,7 @@ use JMS\Serializer\JsonDeserializationVisitor;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\XmlDeserializationVisitor;
 use JMS\Serializer\XmlSerializationVisitor;
@@ -155,7 +156,20 @@ class Module implements
 
                     return new CamelCaseNamingStrategy($options->getSeparator(), $options->getLowercase());
                 },
+                'jms_serializer.identical_naming_strategy' => function (ServiceManager $sm) {
+                    return new IdenticalPropertyNamingStrategy();
+                },
                 'jms_serializer.serialized_name_annotation_strategy' => function (ServiceManager $sm) {
+                    
+                    $options = $sm->get('Configuration');
+                    
+                    if (isset($options['jms_serializer']['naming_strategy'])) {
+                        
+                        if ($options['jms_serializer']['naming_strategy'] == 'identical') {
+                            return new SerializedNameAnnotationStrategy($sm->get('jms_serializer.identical_naming_strategy'));
+                        }
+                    }
+                    
                     return new SerializedNameAnnotationStrategy($sm->get('jms_serializer.camel_case_naming_strategy'));
                 },
                 'jms_serializer.naming_strategy' => 'JMSSerializerModule\Service\NamingStrategyFactory',


### PR DESCRIPTION
I have added a new configuration parameter to be able to set the naming strategy. It maintains the default as the CamelCase strategy but with the following specification we can use the identical naming strategy.

I have also updated the configuration documentation to show that new configuration option.

``` php
    'jms_serializer' => array(
      'naming_strategy' => 'identical'
    ),
```
